### PR TITLE
feat: Add Staff/Store CRUD operations and APK version management system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ go.work
 # Build directories
 bin/
 dist/
+build/
 
 # Database files
 *.db
@@ -50,6 +51,9 @@ Thumbs.db
 # Temporary files
 tmp/
 temp/
+
+# Upload directories
+uploads/
 
 # Air for live reload
 .air.toml

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
+	github.com/stretchr/testify v1.11.1
 	modernc.org/sqlite v1.39.0
 )
 
@@ -14,6 +15,7 @@ require (
 	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
@@ -30,6 +32,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
@@ -46,6 +49,7 @@ require (
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.66.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,7 @@ golang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
 golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/handlers/api.go
+++ b/pkg/handlers/api.go
@@ -179,14 +179,41 @@ func (h *Handlers) APIStoresCreate(c *gin.Context) {
 
 // APIStoresUpdate updates a store via API
 func (h *Handlers) APIStoresUpdate(c *gin.Context) {
-	// TODO: Implement store update
-	c.JSON(http.StatusNotImplemented, gin.H{"error": "Not implemented"})
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	var store models.Store
+	if err := c.ShouldBindJSON(&store); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	store.ID = id
+	if err := h.storeService.UpdateStore(&store); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, store)
 }
 
 // APIStoresDelete deletes a store via API
 func (h *Handlers) APIStoresDelete(c *gin.Context) {
-	// TODO: Implement store delete
-	c.JSON(http.StatusNotImplemented, gin.H{"error": "Not implemented"})
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	if err := h.storeService.DeleteStore(id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Store deleted successfully"})
 }
 
 // APIStaffsList returns staffs list as JSON
@@ -238,14 +265,41 @@ func (h *Handlers) APIStaffsCreate(c *gin.Context) {
 
 // APIStaffsUpdate updates a staff via API
 func (h *Handlers) APIStaffsUpdate(c *gin.Context) {
-	// TODO: Implement staff update
-	c.JSON(http.StatusNotImplemented, gin.H{"error": "Not implemented"})
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	var staff models.Staff
+	if err := c.ShouldBindJSON(&staff); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	staff.ID = id
+	if err := h.staffService.UpdateStaff(&staff); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, staff)
 }
 
 // APIStaffsDelete deletes a staff via API
 func (h *Handlers) APIStaffsDelete(c *gin.Context) {
-	// TODO: Implement staff delete
-	c.JSON(http.StatusNotImplemented, gin.H{"error": "Not implemented"})
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	if err := h.staffService.DeleteStaff(id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Staff deleted successfully"})
 }
 
 // APISettingsList returns settings list as JSON

--- a/pkg/handlers/api_test.go
+++ b/pkg/handlers/api_test.go
@@ -1,0 +1,554 @@
+package handlers
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/models"
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/repository"
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE staff (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			staffId TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE store (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			storeId TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE sale (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			staffId INTEGER NOT NULL,
+			storeId INTEGER NOT NULL,
+			totalPrice INTEGER NOT NULL,
+			deposit INTEGER NOT NULL,
+			saleAt DATETIME NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (staffId) REFERENCES staff(id),
+			FOREIGN KEY (storeId) REFERENCES store(id)
+		)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE apk_versions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			version TEXT NOT NULL UNIQUE,
+			versionCode INTEGER NOT NULL,
+			fileName TEXT NOT NULL,
+			fileSize INTEGER NOT NULL,
+			filePath TEXT NOT NULL,
+			releaseNotes TEXT,
+			isActive INTEGER NOT NULL DEFAULT 1,
+			uploadedAt DATETIME NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func setupTestRouter(db *sql.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	repos := repository.NewRepositories(db)
+	services := service.NewServices(repos)
+	handlers := NewHandlers(services)
+
+	SetupRoutes(router, handlers)
+
+	return router
+}
+
+func TestAPIStaffsList(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	// Insert test data
+	_, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+		"STAFF-001", "Test Staff 1", time.Now(), time.Now())
+	require.NoError(t, err)
+
+	_, err = db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+		"STAFF-002", "Test Staff 2", time.Now(), time.Now())
+	require.NoError(t, err)
+
+	t.Run("get all staffs", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/staffs", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var staffs []*models.Staff
+		err := json.Unmarshal(w.Body.Bytes(), &staffs)
+		require.NoError(t, err)
+		assert.Len(t, staffs, 2)
+		assert.Equal(t, "Test Staff 2", staffs[0].Name) // DESC order
+	})
+}
+
+func TestAPIStaffsGet(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	// Insert test data
+	result, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+		"STAFF-001", "Test Staff", time.Now(), time.Now())
+	require.NoError(t, err)
+	id, _ := result.LastInsertId()
+
+	t.Run("get existing staff", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/staffs/%d", id), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var staff models.Staff
+		err := json.Unmarshal(w.Body.Bytes(), &staff)
+		require.NoError(t, err)
+		assert.Equal(t, "Test Staff", staff.Name)
+	})
+
+	t.Run("get non-existent staff", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/staffs/999", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestAPIStaffsCreate(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	t.Run("create staff successfully", func(t *testing.T) {
+		staffData := map[string]interface{}{
+			"name": "New Staff",
+		}
+		body, _ := json.Marshal(staffData)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/api/staffs", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var staff models.Staff
+		err := json.Unmarshal(w.Body.Bytes(), &staff)
+		require.NoError(t, err)
+		assert.Equal(t, "New Staff", staff.Name)
+		assert.NotEmpty(t, staff.StaffID)
+	})
+
+	t.Run("create staff with empty name", func(t *testing.T) {
+		staffData := map[string]interface{}{
+			"name": "",
+		}
+		body, _ := json.Marshal(staffData)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/api/staffs", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestAPIStaffsUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	// Insert test data
+	result, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+		"STAFF-001", "Original Name", time.Now(), time.Now())
+	require.NoError(t, err)
+	id, _ := result.LastInsertId()
+
+	t.Run("update staff successfully", func(t *testing.T) {
+		staffData := map[string]interface{}{
+			"name": "Updated Name",
+		}
+		body, _ := json.Marshal(staffData)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/api/staffs/%d", id), bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var staff models.Staff
+		err := json.Unmarshal(w.Body.Bytes(), &staff)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Name", staff.Name)
+	})
+
+	t.Run("update non-existent staff", func(t *testing.T) {
+		staffData := map[string]interface{}{
+			"name": "Updated Name",
+		}
+		body, _ := json.Marshal(staffData)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPut, "/api/staffs/999", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestAPIStaffsDelete(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	t.Run("delete staff successfully", func(t *testing.T) {
+		// Insert test data
+		result, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STAFF-DEL", "To Delete", time.Now(), time.Now())
+		require.NoError(t, err)
+		id, _ := result.LastInsertId()
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("/api/staffs/%d", id), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Verify deletion
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM staff WHERE id = ?", id).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("delete staff with sales - should fail", func(t *testing.T) {
+		// Insert staff
+		result, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STAFF-REF", "Has Sales", time.Now(), time.Now())
+		require.NoError(t, err)
+		staffID, _ := result.LastInsertId()
+
+		// Insert store
+		storeResult, err := db.Exec("INSERT INTO store (storeId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STORE-001", "Test Store", time.Now(), time.Now())
+		require.NoError(t, err)
+		storeID, _ := storeResult.LastInsertId()
+
+		// Insert sale referencing staff
+		_, err = db.Exec("INSERT INTO sale (staffId, storeId, totalPrice, deposit, saleAt) VALUES (?, ?, ?, ?, ?)",
+			staffID, storeID, 1000, 1000, time.Now())
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("/api/staffs/%d", staffID), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+		var response map[string]string
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Contains(t, response["error"], "referenced by")
+	})
+
+	t.Run("delete non-existent staff", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodDelete, "/api/staffs/999", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+// Store API Tests
+func TestAPIStoresDelete(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	t.Run("delete store successfully", func(t *testing.T) {
+		// Insert test data
+		result, err := db.Exec("INSERT INTO store (storeId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STORE-DEL", "To Delete", time.Now(), time.Now())
+		require.NoError(t, err)
+		id, _ := result.LastInsertId()
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("/api/stores/%d", id), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Verify deletion
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM store WHERE id = ?", id).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("delete store with sales - should fail", func(t *testing.T) {
+		// Insert store
+		result, err := db.Exec("INSERT INTO store (storeId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STORE-REF", "Has Sales", time.Now(), time.Now())
+		require.NoError(t, err)
+		storeID, _ := result.LastInsertId()
+
+		// Insert staff
+		staffResult, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STAFF-001", "Test Staff", time.Now(), time.Now())
+		require.NoError(t, err)
+		staffID, _ := staffResult.LastInsertId()
+
+		// Insert sale referencing store
+		_, err = db.Exec("INSERT INTO sale (staffId, storeId, totalPrice, deposit, saleAt) VALUES (?, ?, ?, ?, ?)",
+			staffID, storeID, 1000, 1000, time.Now())
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("/api/stores/%d", storeID), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+		var response map[string]string
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Contains(t, response["error"], "referenced by")
+	})
+}
+
+// APK API Tests
+func TestAPIApkLatest(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	t.Run("no versions available", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/apk/version/latest", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("get latest version", func(t *testing.T) {
+		// Insert test data
+		_, err := db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"1.0.0", 1, "test1.apk", 1000, "/tmp/test1.apk", "First release", 1, time.Now())
+		require.NoError(t, err)
+
+		_, err = db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"1.1.0", 2, "test2.apk", 2000, "/tmp/test2.apk", "Second release", 1, time.Now())
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/apk/version/latest", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var apk models.ApkVersion
+		err = json.Unmarshal(w.Body.Bytes(), &apk)
+		require.NoError(t, err)
+		assert.Equal(t, "1.1.0", apk.Version)
+		assert.Equal(t, 2, apk.VersionCode)
+	})
+}
+
+func TestAPIApkCheckUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	// Insert test data
+	_, err := db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		"1.0.0", 1, "test1.apk", 1000, "/tmp/test1.apk", "First release", 1, time.Now())
+	require.NoError(t, err)
+
+	_, err = db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		"2.0.0", 2, "test2.apk", 2000, "/tmp/test2.apk", "Second release", 1, time.Now())
+	require.NoError(t, err)
+
+	t.Run("update available", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/apk/version/check?currentVersionCode=1", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.True(t, response["hasUpdate"].(bool))
+		assert.NotNil(t, response["latestVersion"])
+	})
+
+	t.Run("no update available", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/apk/version/check?currentVersionCode=2", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.False(t, response["hasUpdate"].(bool))
+		assert.Nil(t, response["latestVersion"])
+	})
+
+	t.Run("missing version code", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/apk/version/check", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestAPIApkVersions(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	t.Run("get all versions", func(t *testing.T) {
+		// Insert test data
+		_, err := db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"1.0.0", 1, "test1.apk", 1000, "/tmp/test1.apk", "First", 1, time.Now())
+		require.NoError(t, err)
+
+		_, err = db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"2.0.0", 2, "test2.apk", 2000, "/tmp/test2.apk", "Second", 1, time.Now())
+		require.NoError(t, err)
+
+		_, err = db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"3.0.0", 3, "test3.apk", 3000, "/tmp/test3.apk", "Third", 0, time.Now())
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/apk/version/all", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var versions []*models.ApkVersion
+		err = json.Unmarshal(w.Body.Bytes(), &versions)
+		require.NoError(t, err)
+		// Only active versions should be returned
+		assert.Len(t, versions, 2)
+	})
+}
+
+func TestAPIApkDelete(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	t.Run("delete version successfully", func(t *testing.T) {
+		// Insert test data
+		result, err := db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"1.0.0", 1, "test.apk", 1000, "/tmp/test.apk", "Test", 1, time.Now())
+		require.NoError(t, err)
+		id, _ := result.LastInsertId()
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("/api/apk/version/%d", id), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Verify deletion
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM apk_versions WHERE id = ?", id).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+}
+
+func TestAPIApkDeactivate(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	router := setupTestRouter(db)
+
+	t.Run("deactivate version successfully", func(t *testing.T) {
+		// Insert test data
+		result, err := db.Exec("INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"1.0.0", 1, "test.apk", 1000, "/tmp/test.apk", "Test", 1, time.Now())
+		require.NoError(t, err)
+		id, _ := result.LastInsertId()
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/api/apk/version/%d/deactivate", id), nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Verify deactivation
+		var isActive int
+		err = db.QueryRow("SELECT isActive FROM apk_versions WHERE id = ?", id).Scan(&isActive)
+		require.NoError(t, err)
+		assert.Equal(t, 0, isActive)
+
+		var apk models.ApkVersion
+		err = json.Unmarshal(w.Body.Bytes(), &apk)
+		require.NoError(t, err)
+		assert.False(t, apk.IsActive)
+	})
+}
+

--- a/pkg/handlers/apk_api.go
+++ b/pkg/handlers/apk_api.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/models"
+	"github.com/gin-gonic/gin"
+)
+
+// APIApkLatest returns the latest APK version
+func (h *Handlers) APIApkLatest(c *gin.Context) {
+	version, err := h.apkVersionService.GetLatestVersion()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if version == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "No APK versions available"})
+		return
+	}
+
+	c.JSON(http.StatusOK, version)
+}
+
+// APIApkCheckUpdate checks for updates
+func (h *Handlers) APIApkCheckUpdate(c *gin.Context) {
+	versionCodeStr := c.Query("currentVersionCode")
+	if versionCodeStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "currentVersionCode is required"})
+		return
+	}
+
+	currentVersionCode, err := strconv.Atoi(versionCodeStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid version code"})
+		return
+	}
+
+	newerVersion, err := h.apkVersionService.CheckForUpdate(currentVersionCode)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if newerVersion == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"hasUpdate":     false,
+			"latestVersion": nil,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"hasUpdate":     true,
+		"latestVersion": newerVersion,
+	})
+}
+
+// APIApkVersions returns all APK versions
+func (h *Handlers) APIApkVersions(c *gin.Context) {
+	versions, err := h.apkVersionService.GetAllVersions()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if versions == nil {
+		versions = make([]*models.ApkVersion, 0)
+	}
+
+	c.JSON(http.StatusOK, versions)
+}
+
+// APIApkDownload downloads an APK file by ID
+func (h *Handlers) APIApkDownload(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	// Get APK version
+	version, err := h.apkVersionService.GetVersion(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "APK version not found"})
+		return
+	}
+
+	// Get file path
+	filePath, err := h.apkVersionService.GetApkFilePath(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Serve file
+	c.Header("Content-Description", "File Transfer")
+	c.Header("Content-Transfer-Encoding", "binary")
+	c.Header("Content-Disposition", "attachment; filename="+version.FileName)
+	c.Header("Content-Type", "application/vnd.android.package-archive")
+	c.File(filePath)
+}
+
+// APIApkDownloadLatest downloads the latest APK file
+func (h *Handlers) APIApkDownloadLatest(c *gin.Context) {
+	version, err := h.apkVersionService.GetLatestVersion()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if version == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "No APK versions available"})
+		return
+	}
+
+	// Get file path
+	filePath, err := h.apkVersionService.GetApkFilePath(version.ID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Serve file
+	c.Header("Content-Description", "File Transfer")
+	c.Header("Content-Transfer-Encoding", "binary")
+	c.Header("Content-Disposition", "attachment; filename="+version.FileName)
+	c.Header("Content-Type", "application/vnd.android.package-archive")
+	c.File(filePath)
+}
+
+// APIApkUpload uploads a new APK file
+func (h *Handlers) APIApkUpload(c *gin.Context) {
+	// Parse multipart form
+	file, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "File is required"})
+		return
+	}
+
+	version := c.PostForm("version")
+	versionCodeStr := c.PostForm("versionCode")
+	releaseNotes := c.DefaultPostForm("releaseNotes", "")
+
+	if version == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Version is required"})
+		return
+	}
+	if versionCodeStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Version code is required"})
+		return
+	}
+
+	versionCode, err := strconv.Atoi(versionCodeStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid version code"})
+		return
+	}
+
+	// Upload APK
+	apk, err := h.apkVersionService.UploadApk(file, version, versionCode, releaseNotes)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, apk)
+}
+
+// APIApkDelete deletes an APK version
+func (h *Handlers) APIApkDelete(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	if err := h.apkVersionService.DeleteVersion(id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "APK version deleted successfully"})
+}
+
+// APIApkDeactivate deactivates an APK version
+func (h *Handlers) APIApkDeactivate(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	apk, err := h.apkVersionService.DeactivateVersion(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, apk)
+}

--- a/pkg/handlers/apk_web.go
+++ b/pkg/handlers/apk_web.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ApkList displays APK versions list page
+func (h *Handlers) ApkList(c *gin.Context) {
+	versions, err := h.apkVersionService.GetAllVersions()
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.HTML(http.StatusOK, "apk/index.html", gin.H{
+		"title":    "APK Versions",
+		"versions": versions,
+	})
+}
+
+// ApkUploadPage displays APK upload form
+func (h *Handlers) ApkUploadPage(c *gin.Context) {
+	c.HTML(http.StatusOK, "apk/upload.html", gin.H{
+		"title": "Upload APK",
+	})
+}
+
+// ApkUpload handles APK file upload
+func (h *Handlers) ApkUpload(c *gin.Context) {
+	file, err := c.FormFile("file")
+	if err != nil {
+		c.HTML(http.StatusBadRequest, "apk/upload.html", gin.H{
+			"title": "Upload APK",
+			"error": "File is required",
+		})
+		return
+	}
+
+	version := c.PostForm("version")
+	versionCodeStr := c.PostForm("versionCode")
+	releaseNotes := c.DefaultPostForm("releaseNotes", "")
+
+	if version == "" {
+		c.HTML(http.StatusBadRequest, "apk/upload.html", gin.H{
+			"title": "Upload APK",
+			"error": "Version is required",
+		})
+		return
+	}
+	if versionCodeStr == "" {
+		c.HTML(http.StatusBadRequest, "apk/upload.html", gin.H{
+			"title": "Upload APK",
+			"error": "Version code is required",
+		})
+		return
+	}
+
+	versionCode, err := strconv.Atoi(versionCodeStr)
+	if err != nil {
+		c.HTML(http.StatusBadRequest, "apk/upload.html", gin.H{
+			"title": "Upload APK",
+			"error": "Invalid version code",
+		})
+		return
+	}
+
+	// Upload APK
+	_, err = h.apkVersionService.UploadApk(file, version, versionCode, releaseNotes)
+	if err != nil {
+		c.HTML(http.StatusBadRequest, "apk/upload.html", gin.H{
+			"title": "Upload APK",
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.Redirect(http.StatusSeeOther, "/apk")
+}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -12,21 +12,23 @@ import (
 
 // Handlers holds all handler instances
 type Handlers struct {
-	itemService    *service.ItemService
-	storeService   *service.StoreService
-	staffService   *service.StaffService
-	saleService    *service.SaleService
-	settingService *service.SettingService
+	itemService       *service.ItemService
+	storeService      *service.StoreService
+	staffService      *service.StaffService
+	saleService       *service.SaleService
+	settingService    *service.SettingService
+	apkVersionService *service.ApkVersionService
 }
 
 // NewHandlers creates handler instances
 func NewHandlers(services *service.Services) *Handlers {
 	return &Handlers{
-		itemService:    services.Item,
-		storeService:   services.Store,
-		staffService:   services.Staff,
-		saleService:    services.Sale,
-		settingService: services.Setting,
+		itemService:       services.Item,
+		storeService:      services.Store,
+		staffService:      services.Staff,
+		saleService:       services.Sale,
+		settingService:    services.Setting,
+		apkVersionService: services.ApkVersion,
 	}
 }
 
@@ -261,13 +263,34 @@ func (h *Handlers) StoresEdit(c *gin.Context) {
 
 // StoresUpdate updates a store
 func (h *Handlers) StoresUpdate(c *gin.Context) {
-	// TODO: Implement store update
+	id := atoi(c.Param("id"))
+	store := &models.Store{
+		ID:   id,
+		Name: c.PostForm("name"),
+	}
+
+	if err := h.storeService.UpdateStore(store); err != nil {
+		c.HTML(http.StatusBadRequest, "stores/edit.html", gin.H{
+			"title": "Edit Store",
+			"error": err.Error(),
+			"store": store,
+		})
+		return
+	}
+
 	c.Redirect(http.StatusSeeOther, "/stores")
 }
 
 // StoresDelete deletes a store
 func (h *Handlers) StoresDelete(c *gin.Context) {
-	// TODO: Implement store delete
+	id := atoi(c.Param("id"))
+	if err := h.storeService.DeleteStore(id); err != nil {
+		c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
 	c.Redirect(http.StatusSeeOther, "/stores")
 }
 
@@ -331,13 +354,34 @@ func (h *Handlers) StaffsEdit(c *gin.Context) {
 
 // StaffsUpdate updates a staff
 func (h *Handlers) StaffsUpdate(c *gin.Context) {
-	// TODO: Implement staff update
+	id := atoi(c.Param("id"))
+	staff := &models.Staff{
+		ID:   id,
+		Name: c.PostForm("name"),
+	}
+
+	if err := h.staffService.UpdateStaff(staff); err != nil {
+		c.HTML(http.StatusBadRequest, "staffs/edit.html", gin.H{
+			"title": "Edit Staff",
+			"error": err.Error(),
+			"staff": staff,
+		})
+		return
+	}
+
 	c.Redirect(http.StatusSeeOther, "/staffs")
 }
 
 // StaffsDelete deletes a staff
 func (h *Handlers) StaffsDelete(c *gin.Context) {
-	// TODO: Implement staff delete
+	id := atoi(c.Param("id"))
+	if err := h.staffService.DeleteStaff(id); err != nil {
+		c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
 	c.Redirect(http.StatusSeeOther, "/staffs")
 }
 

--- a/pkg/handlers/router.go
+++ b/pkg/handlers/router.go
@@ -35,6 +35,10 @@ func SetupRoutes(router *gin.Engine, h *Handlers) {
 	router.GET("/settings", h.SettingsList)
 	router.GET("/reports/sales", h.ReportsSales)
 
+	router.GET("/apk", h.ApkList)
+	router.GET("/apk/upload", h.ApkUploadPage)
+	router.POST("/apk/upload", h.ApkUpload)
+
 	// API routes
 	api := router.Group("/api")
 	{
@@ -65,5 +69,14 @@ func SetupRoutes(router *gin.Engine, h *Handlers) {
 
 		api.GET("/reports/sales", h.APIReportsSales)
 		api.GET("/reports/sales/excel", h.APIReportsSalesExcel)
+
+		api.GET("/apk/version/latest", h.APIApkLatest)
+		api.GET("/apk/version/check", h.APIApkCheckUpdate)
+		api.GET("/apk/version/all", h.APIApkVersions)
+		api.GET("/apk/download/:id", h.APIApkDownload)
+		api.GET("/apk/download/latest", h.APIApkDownloadLatest)
+		api.POST("/apk/upload", h.APIApkUpload)
+		api.DELETE("/apk/version/:id", h.APIApkDelete)
+		api.PUT("/apk/version/:id/deactivate", h.APIApkDeactivate)
 	}
 }

--- a/pkg/handlers/web_test.go
+++ b/pkg/handlers/web_test.go
@@ -1,0 +1,14 @@
+package handlers
+
+// Web UI tests are intentionally minimal because:
+// 1. Template rendering requires complex setup with custom functions
+// 2. Web UI testing is better suited for E2E tests with tools like Playwright
+// 3. The API layer tests already cover the business logic thoroughly
+//
+// The API tests (api_test.go) provide comprehensive coverage of:
+// - All CRUD operations
+// - Validation logic
+// - Error handling
+// - Foreign key constraints
+//
+// For full Web UI testing, consider implementing E2E tests separately.

--- a/pkg/models/apk.go
+++ b/pkg/models/apk.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+// ApkVersion represents an APK version
+type ApkVersion struct {
+	ID           int       `json:"id" db:"id"`
+	Version      string    `json:"version" db:"version"`
+	VersionCode  int       `json:"versionCode" db:"versionCode"`
+	FileName     string    `json:"fileName" db:"fileName"`
+	FileSize     int64     `json:"fileSize" db:"fileSize"`
+	FilePath     string    `json:"filePath" db:"filePath"`
+	ReleaseNotes string    `json:"releaseNotes" db:"releaseNotes"`
+	IsActive     bool      `json:"isActive" db:"isActive"`
+	UploadedAt   time.Time `json:"uploadedAt" db:"uploadedAt"`
+	CreatedAt    time.Time `json:"createdAt" db:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt" db:"updatedAt"`
+}

--- a/pkg/repository/apk_repository.go
+++ b/pkg/repository/apk_repository.go
@@ -1,0 +1,180 @@
+package repository
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/models"
+)
+
+// ApkVersionRepository handles APK version data access
+type ApkVersionRepository struct {
+	db *sql.DB
+}
+
+// FindLatest returns the latest active APK version
+func (r *ApkVersionRepository) FindLatest() (*models.ApkVersion, error) {
+	query := `SELECT id, version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt, createdAt, updatedAt
+			  FROM apk_versions WHERE isActive = 1 ORDER BY versionCode DESC LIMIT 1`
+
+	apk := &models.ApkVersion{}
+	err := r.db.QueryRow(query).Scan(&apk.ID, &apk.Version, &apk.VersionCode, &apk.FileName,
+		&apk.FileSize, &apk.FilePath, &apk.ReleaseNotes, &apk.IsActive, &apk.UploadedAt, &apk.CreatedAt, &apk.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return apk, nil
+}
+
+// FindByID finds an APK version by ID
+func (r *ApkVersionRepository) FindByID(id int) (*models.ApkVersion, error) {
+	query := `SELECT id, version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt, createdAt, updatedAt
+			  FROM apk_versions WHERE id = ?`
+
+	apk := &models.ApkVersion{}
+	err := r.db.QueryRow(query, id).Scan(&apk.ID, &apk.Version, &apk.VersionCode, &apk.FileName,
+		&apk.FileSize, &apk.FilePath, &apk.ReleaseNotes, &apk.IsActive, &apk.UploadedAt, &apk.CreatedAt, &apk.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("apk version not found")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return apk, nil
+}
+
+// FindAll returns all active APK versions
+func (r *ApkVersionRepository) FindAll() ([]*models.ApkVersion, error) {
+	query := `SELECT id, version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt, createdAt, updatedAt
+			  FROM apk_versions WHERE isActive = 1 ORDER BY versionCode DESC`
+
+	rows, err := r.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var versions []*models.ApkVersion
+	for rows.Next() {
+		apk := &models.ApkVersion{}
+		err := rows.Scan(&apk.ID, &apk.Version, &apk.VersionCode, &apk.FileName,
+			&apk.FileSize, &apk.FilePath, &apk.ReleaseNotes, &apk.IsActive, &apk.UploadedAt, &apk.CreatedAt, &apk.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, apk)
+	}
+	return versions, nil
+}
+
+// FindByVersionCode finds APK versions with version code greater than the given code
+func (r *ApkVersionRepository) FindByVersionCode(code int) (*models.ApkVersion, error) {
+	query := `SELECT id, version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt, createdAt, updatedAt
+			  FROM apk_versions WHERE isActive = 1 AND versionCode > ? ORDER BY versionCode DESC LIMIT 1`
+
+	apk := &models.ApkVersion{}
+	err := r.db.QueryRow(query, code).Scan(&apk.ID, &apk.Version, &apk.VersionCode, &apk.FileName,
+		&apk.FileSize, &apk.FilePath, &apk.ReleaseNotes, &apk.IsActive, &apk.UploadedAt, &apk.CreatedAt, &apk.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return apk, nil
+}
+
+// Create creates a new APK version
+func (r *ApkVersionRepository) Create(apk *models.ApkVersion) error {
+	query := `INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt, createdAt, updatedAt)
+			  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	now := time.Now()
+	result, err := r.db.Exec(query, apk.Version, apk.VersionCode, apk.FileName, apk.FileSize,
+		apk.FilePath, apk.ReleaseNotes, apk.IsActive, apk.UploadedAt, now, now)
+	if err != nil {
+		return err
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return err
+	}
+	apk.ID = int(id)
+	apk.CreatedAt = now
+	apk.UpdatedAt = now
+
+	return nil
+}
+
+// Update updates an APK version
+func (r *ApkVersionRepository) Update(apk *models.ApkVersion) error {
+	query := `UPDATE apk_versions SET version = ?, versionCode = ?, fileName = ?, fileSize = ?,
+			  filePath = ?, releaseNotes = ?, isActive = ?, updatedAt = ? WHERE id = ?`
+
+	now := time.Now()
+	result, err := r.db.Exec(query, apk.Version, apk.VersionCode, apk.FileName, apk.FileSize,
+		apk.FilePath, apk.ReleaseNotes, apk.IsActive, now, apk.ID)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("apk version not found")
+	}
+
+	apk.UpdatedAt = now
+	return nil
+}
+
+// Delete deletes an APK version
+func (r *ApkVersionRepository) Delete(id int) error {
+	query := `DELETE FROM apk_versions WHERE id = ?`
+	result, err := r.db.Exec(query, id)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("apk version not found")
+	}
+
+	return nil
+}
+
+// Deactivate deactivates an APK version
+func (r *ApkVersionRepository) Deactivate(id int) (*models.ApkVersion, error) {
+	query := `UPDATE apk_versions SET isActive = 0, updatedAt = ? WHERE id = ?`
+
+	now := time.Now()
+	result, err := r.db.Exec(query, now, id)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	if rows == 0 {
+		return nil, fmt.Errorf("apk version not found")
+	}
+
+	// Return the updated version
+	return r.FindByID(id)
+}

--- a/pkg/repository/apk_repository_test.go
+++ b/pkg/repository/apk_repository_test.go
@@ -1,0 +1,303 @@
+package repository
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func setupAPKTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	// Create apk_versions table
+	_, err = db.Exec(`
+		CREATE TABLE apk_versions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			version TEXT NOT NULL UNIQUE,
+			versionCode INTEGER NOT NULL,
+			fileName TEXT NOT NULL,
+			fileSize INTEGER NOT NULL,
+			filePath TEXT NOT NULL,
+			releaseNotes TEXT,
+			isActive INTEGER NOT NULL DEFAULT 1,
+			uploadedAt DATETIME NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func createTestAPK(t *testing.T, db *sql.DB, version string, versionCode int, isActive bool) int {
+	activeInt := 0
+	if isActive {
+		activeInt = 1
+	}
+
+	result, err := db.Exec(`
+		INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, version, versionCode, "test.apk", 1000, "/path/to/test.apk", "Test release", activeInt, time.Now())
+	require.NoError(t, err)
+
+	id, err := result.LastInsertId()
+	require.NoError(t, err)
+
+	return int(id)
+}
+
+func TestApkRepository_Create(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("successful create", func(t *testing.T) {
+		apk := &models.ApkVersion{
+			Version:      "1.0.0",
+			VersionCode:  1,
+			FileName:     "app-1.0.0.apk",
+			FileSize:     1024000,
+			FilePath:     "/uploads/app-1.0.0.apk",
+			ReleaseNotes: "Initial release",
+			IsActive:     true,
+			UploadedAt:   time.Now(),
+		}
+
+		err := repo.Create(apk)
+		assert.NoError(t, err)
+		assert.NotZero(t, apk.ID)
+	})
+
+	t.Run("create duplicate version - should fail", func(t *testing.T) {
+		apk := &models.ApkVersion{
+			Version:      "1.0.0", // Same as above
+			VersionCode:  2,
+			FileName:     "app-1.0.0-2.apk",
+			FileSize:     1024000,
+			FilePath:     "/uploads/app-1.0.0-2.apk",
+			ReleaseNotes: "Duplicate version",
+			IsActive:     true,
+			UploadedAt:   time.Now(),
+		}
+
+		err := repo.Create(apk)
+		assert.Error(t, err)
+	})
+}
+
+func TestApkRepository_FindLatest(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("no versions available", func(t *testing.T) {
+		version, err := repo.FindLatest()
+		assert.NoError(t, err)
+		assert.Nil(t, version)
+	})
+
+	t.Run("return latest active version", func(t *testing.T) {
+		// Create multiple versions
+		createTestAPK(t, db, "1.0.0", 1, true)
+		createTestAPK(t, db, "1.1.0", 2, true)
+		id3 := createTestAPK(t, db, "1.2.0", 3, true)
+		createTestAPK(t, db, "2.0.0", 4, false) // Inactive
+
+		version, err := repo.FindLatest()
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, id3, version.ID)
+		assert.Equal(t, "1.2.0", version.Version)
+		assert.Equal(t, 3, version.VersionCode)
+	})
+}
+
+func TestApkRepository_FindByID(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("find existing version", func(t *testing.T) {
+		id := createTestAPK(t, db, "1.0.0", 1, true)
+
+		version, err := repo.FindByID(id)
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, id, version.ID)
+		assert.Equal(t, "1.0.0", version.Version)
+	})
+
+	t.Run("find non-existent version", func(t *testing.T) {
+		version, err := repo.FindByID(999)
+		assert.Error(t, err)
+		assert.Nil(t, version)
+	})
+}
+
+func TestApkRepository_FindAll(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("no versions", func(t *testing.T) {
+		versions, err := repo.FindAll()
+		require.NoError(t, err)
+		assert.Empty(t, versions)
+	})
+
+	t.Run("return only active versions", func(t *testing.T) {
+		createTestAPK(t, db, "1.0.0", 1, true)
+		createTestAPK(t, db, "1.1.0", 2, true)
+		createTestAPK(t, db, "1.2.0", 3, false) // Inactive
+
+		versions, err := repo.FindAll()
+		require.NoError(t, err)
+		assert.Len(t, versions, 2)
+	})
+
+	t.Run("ordered by versionCode desc", func(t *testing.T) {
+		versions, err := repo.FindAll()
+		require.NoError(t, err)
+		require.Len(t, versions, 2)
+
+		// Should be ordered newest first
+		assert.Equal(t, "1.1.0", versions[0].Version)
+		assert.Equal(t, "1.0.0", versions[1].Version)
+	})
+}
+
+func TestApkRepository_FindByVersionCode(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("no newer versions", func(t *testing.T) {
+		createTestAPK(t, db, "1.0.0", 1, true)
+
+		version, err := repo.FindByVersionCode(1)
+		assert.NoError(t, err)
+		assert.Nil(t, version)
+	})
+
+	t.Run("find newer version", func(t *testing.T) {
+		createTestAPK(t, db, "1.1.0", 2, true)
+		id3 := createTestAPK(t, db, "1.2.0", 3, true)
+
+		version, err := repo.FindByVersionCode(1)
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, id3, version.ID)
+		assert.Equal(t, "1.2.0", version.Version)
+	})
+
+	t.Run("ignore inactive versions", func(t *testing.T) {
+		createTestAPK(t, db, "2.0.0", 4, false) // Inactive
+
+		version, err := repo.FindByVersionCode(3)
+		assert.NoError(t, err)
+		assert.Nil(t, version)
+	})
+}
+
+func TestApkRepository_Update(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("successful update", func(t *testing.T) {
+		id := createTestAPK(t, db, "1.0.0", 1, true)
+
+		apk := &models.ApkVersion{
+			ID:           id,
+			ReleaseNotes: "Updated release notes",
+		}
+
+		err := repo.Update(apk)
+		assert.NoError(t, err)
+
+		// Verify update
+		var notes string
+		err = db.QueryRow("SELECT releaseNotes FROM apk_versions WHERE id = ?", id).Scan(&notes)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated release notes", notes)
+	})
+
+	t.Run("update non-existent version", func(t *testing.T) {
+		apk := &models.ApkVersion{
+			ID:           999,
+			ReleaseNotes: "Will fail",
+		}
+
+		err := repo.Update(apk)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestApkRepository_Delete(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("successful delete", func(t *testing.T) {
+		id := createTestAPK(t, db, "1.0.0", 1, true)
+
+		err := repo.Delete(id)
+		assert.NoError(t, err)
+
+		// Verify deletion
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM apk_versions WHERE id = ?", id).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("delete non-existent version", func(t *testing.T) {
+		err := repo.Delete(999)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestApkRepository_Deactivate(t *testing.T) {
+	db := setupAPKTestDB(t)
+	defer db.Close()
+
+	repo := &ApkVersionRepository{db: db}
+
+	t.Run("successful deactivate", func(t *testing.T) {
+		id := createTestAPK(t, db, "1.0.0", 1, true)
+
+		apk, err := repo.Deactivate(id)
+		require.NoError(t, err)
+		require.NotNil(t, apk)
+		assert.False(t, apk.IsActive)
+
+		// Verify in database
+		var isActive bool
+		err = db.QueryRow("SELECT isActive FROM apk_versions WHERE id = ?", id).Scan(&isActive)
+		require.NoError(t, err)
+		assert.False(t, isActive)
+	})
+
+	t.Run("deactivate non-existent version", func(t *testing.T) {
+		apk, err := repo.Deactivate(999)
+		assert.Error(t, err)
+		assert.Nil(t, apk)
+	})
+}

--- a/pkg/repository/db.go
+++ b/pkg/repository/db.go
@@ -104,6 +104,20 @@ func RunMigrations(db *sql.DB) error {
 		updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
 
+	CREATE TABLE IF NOT EXISTS apk_versions (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		version TEXT NOT NULL UNIQUE,
+		versionCode INTEGER NOT NULL,
+		fileName TEXT NOT NULL,
+		fileSize INTEGER NOT NULL,
+		filePath TEXT NOT NULL,
+		releaseNotes TEXT,
+		isActive INTEGER NOT NULL DEFAULT 1,
+		uploadedAt DATETIME NOT NULL,
+		createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
 	-- Create indexes
 	CREATE INDEX IF NOT EXISTS idx_item_itemId ON item(itemId);
 	CREATE INDEX IF NOT EXISTS idx_item_isDeleted ON item(isDeleted);
@@ -112,6 +126,9 @@ func RunMigrations(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_sale_saleAt ON sale(saleAt);
 	CREATE INDEX IF NOT EXISTS idx_sale_detail_saleId ON sale_detail(saleId);
 	CREATE INDEX IF NOT EXISTS idx_sale_detail_itemId ON sale_detail(itemId);
+	CREATE INDEX IF NOT EXISTS idx_apk_versions_versionCode ON apk_versions(versionCode);
+	CREATE INDEX IF NOT EXISTS idx_apk_versions_isActive ON apk_versions(isActive);
+	CREATE INDEX IF NOT EXISTS idx_apk_versions_uploadedAt ON apk_versions(uploadedAt);
 
 	-- Insert default settings if not exists
 	INSERT OR IGNORE INTO setting (key, value, type, description) VALUES

--- a/pkg/repository/staff_repository_test.go
+++ b/pkg/repository/staff_repository_test.go
@@ -1,0 +1,138 @@
+package repository
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE staff (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			staffId TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE sale (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			staffId INTEGER NOT NULL,
+			storeId INTEGER NOT NULL,
+			totalPrice INTEGER NOT NULL,
+			deposit INTEGER NOT NULL,
+			saleAt DATETIME NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (staffId) REFERENCES staff(id)
+		)
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestStaffRepository_Update(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	repo := &StaffRepository{db: db}
+
+	// Create a staff first
+	staff := &models.Staff{
+		StaffID: "STAFF-001",
+		Name:    "Test Staff",
+	}
+	_, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+		staff.StaffID, staff.Name, time.Now(), time.Now())
+	require.NoError(t, err)
+
+	// Get the created staff
+	var id int
+	err = db.QueryRow("SELECT id FROM staff WHERE staffId = ?", staff.StaffID).Scan(&id)
+	require.NoError(t, err)
+	staff.ID = id
+
+	t.Run("successful update", func(t *testing.T) {
+		staff.Name = "Updated Staff Name"
+		err := repo.Update(staff)
+		assert.NoError(t, err)
+
+		// Verify the update
+		var name string
+		err = db.QueryRow("SELECT name FROM staff WHERE id = ?", staff.ID).Scan(&name)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Staff Name", name)
+	})
+
+	t.Run("update non-existent staff", func(t *testing.T) {
+		nonExistent := &models.Staff{
+			ID:   999,
+			Name: "Non-existent",
+		}
+		err := repo.Update(nonExistent)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestStaffRepository_Delete(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	repo := &StaffRepository{db: db}
+
+	t.Run("successful delete", func(t *testing.T) {
+		// Create a staff
+		result, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STAFF-002", "Test Staff 2", time.Now(), time.Now())
+		require.NoError(t, err)
+		id, _ := result.LastInsertId()
+
+		// Delete the staff
+		err = repo.Delete(int(id))
+		assert.NoError(t, err)
+
+		// Verify deletion
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM staff WHERE id = ?", id).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("delete staff with sales - should fail", func(t *testing.T) {
+		// Create a staff
+		result, err := db.Exec("INSERT INTO staff (staffId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STAFF-003", "Test Staff 3", time.Now(), time.Now())
+		require.NoError(t, err)
+		staffID, _ := result.LastInsertId()
+
+		// Create a sale referencing this staff
+		_, err = db.Exec("INSERT INTO sale (staffId, storeId, totalPrice, deposit, saleAt) VALUES (?, ?, ?, ?, ?)",
+			staffID, 1, 1000, 1000, time.Now())
+		require.NoError(t, err)
+
+		// Try to delete the staff - should fail
+		err = repo.Delete(int(staffID))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "referenced by")
+	})
+
+	t.Run("delete non-existent staff", func(t *testing.T) {
+		err := repo.Delete(999)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/pkg/repository/store_repository_test.go
+++ b/pkg/repository/store_repository_test.go
@@ -1,0 +1,138 @@
+package repository
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func setupStoreTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE store (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			storeId TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE sale (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			staffId INTEGER NOT NULL,
+			storeId INTEGER NOT NULL,
+			totalPrice INTEGER NOT NULL,
+			deposit INTEGER NOT NULL,
+			saleAt DATETIME NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (storeId) REFERENCES store(id)
+		)
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestStoreRepository_Update(t *testing.T) {
+	db := setupStoreTestDB(t)
+	defer db.Close()
+
+	repo := &StoreRepository{db: db}
+
+	// Create a store first
+	store := &models.Store{
+		StoreID: "STORE-001",
+		Name:    "Test Store",
+	}
+	_, err := db.Exec("INSERT INTO store (storeId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+		store.StoreID, store.Name, time.Now(), time.Now())
+	require.NoError(t, err)
+
+	// Get the created store
+	var id int
+	err = db.QueryRow("SELECT id FROM store WHERE storeId = ?", store.StoreID).Scan(&id)
+	require.NoError(t, err)
+	store.ID = id
+
+	t.Run("successful update", func(t *testing.T) {
+		store.Name = "Updated Store Name"
+		err := repo.Update(store)
+		assert.NoError(t, err)
+
+		// Verify the update
+		var name string
+		err = db.QueryRow("SELECT name FROM store WHERE id = ?", store.ID).Scan(&name)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Store Name", name)
+	})
+
+	t.Run("update non-existent store", func(t *testing.T) {
+		nonExistent := &models.Store{
+			ID:   999,
+			Name: "Non-existent",
+		}
+		err := repo.Update(nonExistent)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestStoreRepository_Delete(t *testing.T) {
+	db := setupStoreTestDB(t)
+	defer db.Close()
+
+	repo := &StoreRepository{db: db}
+
+	t.Run("successful delete", func(t *testing.T) {
+		// Create a store
+		result, err := db.Exec("INSERT INTO store (storeId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STORE-002", "Test Store 2", time.Now(), time.Now())
+		require.NoError(t, err)
+		id, _ := result.LastInsertId()
+
+		// Delete the store
+		err = repo.Delete(int(id))
+		assert.NoError(t, err)
+
+		// Verify deletion
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM store WHERE id = ?", id).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("delete store with sales - should fail", func(t *testing.T) {
+		// Create a store
+		result, err := db.Exec("INSERT INTO store (storeId, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)",
+			"STORE-003", "Test Store 3", time.Now(), time.Now())
+		require.NoError(t, err)
+		storeID, _ := result.LastInsertId()
+
+		// Create a sale referencing this store
+		_, err = db.Exec("INSERT INTO sale (staffId, storeId, totalPrice, deposit, saleAt) VALUES (?, ?, ?, ?, ?)",
+			1, storeID, 1000, 1000, time.Now())
+		require.NoError(t, err)
+
+		// Try to delete the store - should fail
+		err = repo.Delete(int(storeID))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "referenced by")
+	})
+
+	t.Run("delete non-existent store", func(t *testing.T) {
+		err := repo.Delete(999)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/pkg/service/apk_service.go
+++ b/pkg/service/apk_service.go
@@ -1,0 +1,165 @@
+package service
+
+import (
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/models"
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/repository"
+	"github.com/google/uuid"
+)
+
+// ApkVersionService handles APK version business logic
+type ApkVersionService struct {
+	repo        *repository.ApkVersionRepository
+	uploadDir   string
+	maxFileSize int64
+}
+
+// NewApkVersionService creates a new APK version service
+func NewApkVersionService(repo *repository.ApkVersionRepository) *ApkVersionService {
+	uploadDir := "./uploads/apk"
+	// Create upload directory if it doesn't exist
+	if err := os.MkdirAll(uploadDir, 0755); err != nil {
+		fmt.Printf("Warning: failed to create upload directory: %v\n", err)
+	}
+
+	return &ApkVersionService{
+		repo:        repo,
+		uploadDir:   uploadDir,
+		maxFileSize: 100 * 1024 * 1024, // 100MB
+	}
+}
+
+// GetLatestVersion returns the latest active APK version
+func (s *ApkVersionService) GetLatestVersion() (*models.ApkVersion, error) {
+	return s.repo.FindLatest()
+}
+
+// CheckForUpdate checks if there's a newer version available
+func (s *ApkVersionService) CheckForUpdate(currentVersionCode int) (*models.ApkVersion, error) {
+	return s.repo.FindByVersionCode(currentVersionCode)
+}
+
+// GetAllVersions returns all active APK versions
+func (s *ApkVersionService) GetAllVersions() ([]*models.ApkVersion, error) {
+	return s.repo.FindAll()
+}
+
+// GetVersion returns an APK version by ID
+func (s *ApkVersionService) GetVersion(id int) (*models.ApkVersion, error) {
+	return s.repo.FindByID(id)
+}
+
+// UploadApk uploads a new APK file
+func (s *ApkVersionService) UploadApk(file *multipart.FileHeader, version string, versionCode int, releaseNotes string) (*models.ApkVersion, error) {
+	// Validate inputs
+	if version == "" {
+		return nil, fmt.Errorf("version is required")
+	}
+	if versionCode <= 0 {
+		return nil, fmt.Errorf("version code must be positive")
+	}
+
+	// Validate file
+	if file == nil {
+		return nil, fmt.Errorf("file is required")
+	}
+	if file.Size > s.maxFileSize {
+		return nil, fmt.Errorf("file size exceeds maximum of %d bytes", s.maxFileSize)
+	}
+
+	// Check file extension
+	if !strings.HasSuffix(strings.ToLower(file.Filename), ".apk") {
+		return nil, fmt.Errorf("file must be an APK file")
+	}
+
+	// Generate unique filename
+	uniqueID := uuid.New().String()[:8]
+	fileName := fmt.Sprintf("%s-%s.apk", version, uniqueID)
+	filePath := filepath.Join(s.uploadDir, fileName)
+
+	// Save file
+	if err := s.saveFile(file, filePath); err != nil {
+		return nil, fmt.Errorf("failed to save file: %w", err)
+	}
+
+	// Create APK version record
+	apk := &models.ApkVersion{
+		Version:      version,
+		VersionCode:  versionCode,
+		FileName:     fileName,
+		FileSize:     file.Size,
+		FilePath:     filePath,
+		ReleaseNotes: releaseNotes,
+		IsActive:     true,
+		UploadedAt:   time.Now(),
+	}
+
+	if err := s.repo.Create(apk); err != nil {
+		// Clean up file if database insert fails
+		os.Remove(filePath)
+		return nil, fmt.Errorf("failed to create APK version: %w", err)
+	}
+
+	return apk, nil
+}
+
+// GetApkFilePath returns the file path for an APK version
+func (s *ApkVersionService) GetApkFilePath(id int) (string, error) {
+	apk, err := s.repo.FindByID(id)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(apk.FilePath); os.IsNotExist(err) {
+		return "", fmt.Errorf("APK file not found")
+	}
+
+	return apk.FilePath, nil
+}
+
+// DeleteVersion deletes an APK version and its file
+func (s *ApkVersionService) DeleteVersion(id int) error {
+	apk, err := s.repo.FindByID(id)
+	if err != nil {
+		return err
+	}
+
+	// Delete file
+	if err := os.Remove(apk.FilePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete file: %w", err)
+	}
+
+	// Delete database record
+	return s.repo.Delete(id)
+}
+
+// DeactivateVersion deactivates an APK version
+func (s *ApkVersionService) DeactivateVersion(id int) (*models.ApkVersion, error) {
+	return s.repo.Deactivate(id)
+}
+
+// saveFile saves an uploaded file to the specified path
+func (s *ApkVersionService) saveFile(file *multipart.FileHeader, dst string) error {
+	src, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, src)
+	return err
+}

--- a/pkg/service/apk_service_test.go
+++ b/pkg/service/apk_service_test.go
@@ -1,0 +1,314 @@
+package service
+
+import (
+	"bytes"
+	"database/sql"
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func setupAPKServiceTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	// Create apk_versions table
+	_, err = db.Exec(`
+		CREATE TABLE apk_versions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			version TEXT NOT NULL UNIQUE,
+			versionCode INTEGER NOT NULL,
+			fileName TEXT NOT NULL,
+			fileSize INTEGER NOT NULL,
+			filePath TEXT NOT NULL,
+			releaseNotes TEXT,
+			isActive INTEGER NOT NULL DEFAULT 1,
+			uploadedAt DATETIME NOT NULL,
+			createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func createTestFileHeader(t *testing.T, filename string, content []byte) *multipart.FileHeader {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	part, err := writer.CreateFormFile("file", filename)
+	require.NoError(t, err)
+
+	_, err = io.Copy(part, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	err = writer.Close()
+	require.NoError(t, err)
+
+	// Parse the multipart form
+	reader := multipart.NewReader(body, writer.Boundary())
+	form, err := reader.ReadForm(10 << 20) // 10MB
+	require.NoError(t, err)
+
+	files := form.File["file"]
+	require.Len(t, files, 1)
+
+	return files[0]
+}
+
+func TestApkVersionService_UploadApk(t *testing.T) {
+	db := setupAPKServiceTestDB(t)
+	defer db.Close()
+
+	// Create temporary directory for test
+	tmpDir, err := os.MkdirTemp("", "apk-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	repo := &repository.ApkVersionRepository{}
+	service := NewApkVersionService(repo)
+	service.uploadDir = tmpDir
+
+	// Set the repository's db
+	repoStruct := (*struct {
+		db *sql.DB
+	})(unsafe.Pointer(repo))
+	repoStruct.db = db
+
+	t.Run("successful upload", func(t *testing.T) {
+		fileHeader := createTestFileHeader(t, "test.apk", []byte("test content"))
+
+		apk, err := service.UploadApk(fileHeader, "1.0.0", 1, "Test release")
+		require.NoError(t, err)
+		require.NotNil(t, apk)
+
+		assert.Equal(t, "1.0.0", apk.Version)
+		assert.Equal(t, 1, apk.VersionCode)
+		assert.Equal(t, "Test release", apk.ReleaseNotes)
+		assert.True(t, apk.IsActive)
+
+		// Verify file was saved
+		_, err = os.Stat(apk.FilePath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing version", func(t *testing.T) {
+		fileHeader := createTestFileHeader(t, "test.apk", []byte("test content"))
+
+		apk, err := service.UploadApk(fileHeader, "", 1, "Test release")
+		assert.Error(t, err)
+		assert.Nil(t, apk)
+		assert.Contains(t, err.Error(), "version is required")
+	})
+
+	t.Run("invalid version code", func(t *testing.T) {
+		fileHeader := createTestFileHeader(t, "test.apk", []byte("test content"))
+
+		apk, err := service.UploadApk(fileHeader, "1.0.0", 0, "Test release")
+		assert.Error(t, err)
+		assert.Nil(t, apk)
+		assert.Contains(t, err.Error(), "version code must be positive")
+	})
+
+	t.Run("file too large", func(t *testing.T) {
+		// Create a large content (more than 100MB)
+		largeContent := make([]byte, 101*1024*1024)
+		fileHeader := createTestFileHeader(t, "large.apk", largeContent)
+
+		apk, err := service.UploadApk(fileHeader, "1.0.0", 1, "Test release")
+		assert.Error(t, err)
+		assert.Nil(t, apk)
+		assert.Contains(t, err.Error(), "file size exceeds")
+	})
+
+	t.Run("non-apk file", func(t *testing.T) {
+		fileHeader := createTestFileHeader(t, "test.txt", []byte("test content"))
+
+		apk, err := service.UploadApk(fileHeader, "1.0.0", 1, "Test release")
+		assert.Error(t, err)
+		assert.Nil(t, apk)
+		assert.Contains(t, err.Error(), "must be an APK file")
+	})
+}
+
+func TestApkVersionService_GetLatestVersion(t *testing.T) {
+	db := setupAPKServiceTestDB(t)
+	defer db.Close()
+
+	repo := &repository.ApkVersionRepository{}
+	service := NewApkVersionService(repo)
+
+	// Set the repository's db using reflection
+	repoStruct := (*struct {
+		db *sql.DB
+	})(unsafe.Pointer(repo))
+	repoStruct.db = db
+
+	t.Run("no versions", func(t *testing.T) {
+		version, err := service.GetLatestVersion()
+		assert.NoError(t, err)
+		assert.Nil(t, version)
+	})
+
+	t.Run("get latest version", func(t *testing.T) {
+		// Insert test data
+		_, err := db.Exec(`INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "1.0.0", 1, "test.apk", 1000, "/path", "notes", 1, time.Now())
+		require.NoError(t, err)
+
+		_, err = db.Exec(`INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "1.1.0", 2, "test.apk", 1000, "/path", "notes", 1, time.Now())
+		require.NoError(t, err)
+
+		version, err := service.GetLatestVersion()
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, "1.1.0", version.Version)
+	})
+}
+
+func TestApkVersionService_CheckForUpdate(t *testing.T) {
+	db := setupAPKServiceTestDB(t)
+	defer db.Close()
+
+	repo := &repository.ApkVersionRepository{}
+	service := NewApkVersionService(repo)
+
+	// Set the repository's db
+	repoStruct := (*struct {
+		db *sql.DB
+	})(unsafe.Pointer(repo))
+	repoStruct.db = db
+
+	// Insert test data
+	_, err := db.Exec(`INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "1.0.0", 1, "test.apk", 1000, "/path", "notes", 1, time.Now())
+	require.NoError(t, err)
+
+	_, err = db.Exec(`INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "2.0.0", 2, "test.apk", 1000, "/path", "notes", 1, time.Now())
+	require.NoError(t, err)
+
+	t.Run("update available", func(t *testing.T) {
+		version, err := service.CheckForUpdate(1)
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, "2.0.0", version.Version)
+	})
+
+	t.Run("no update available", func(t *testing.T) {
+		version, err := service.CheckForUpdate(2)
+		require.NoError(t, err)
+		assert.Nil(t, version)
+	})
+}
+
+func TestApkVersionService_DeleteVersion(t *testing.T) {
+	db := setupAPKServiceTestDB(t)
+	defer db.Close()
+
+	// Create temporary directory for test
+	tmpDir, err := os.MkdirTemp("", "apk-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	repo := &repository.ApkVersionRepository{}
+	service := NewApkVersionService(repo)
+	service.uploadDir = tmpDir
+
+	// Set the repository's db
+	repoStruct := (*struct {
+		db *sql.DB
+	})(unsafe.Pointer(repo))
+	repoStruct.db = db
+
+	t.Run("successful delete with file", func(t *testing.T) {
+		// Create a test file
+		testFilePath := filepath.Join(tmpDir, "test.apk")
+		err := os.WriteFile(testFilePath, []byte("test content"), 0644)
+		require.NoError(t, err)
+
+		// Insert test data
+		result, err := db.Exec(`INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "1.0.0", 1, "test.apk", 1000, testFilePath, "notes", 1, time.Now())
+		require.NoError(t, err)
+
+		id, err := result.LastInsertId()
+		require.NoError(t, err)
+
+		err = service.DeleteVersion(int(id))
+		assert.NoError(t, err)
+
+		// Verify file was deleted
+		_, err = os.Stat(testFilePath)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("delete without physical file", func(t *testing.T) {
+		// Insert test data with non-existent file path
+		result, err := db.Exec(`INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "2.0.0", 2, "test.apk", 1000, "/nonexistent/file.apk", "notes", 1, time.Now())
+		require.NoError(t, err)
+
+		id, err := result.LastInsertId()
+		require.NoError(t, err)
+
+		err = service.DeleteVersion(int(id))
+		assert.NoError(t, err) // Should succeed even if file doesn't exist
+	})
+}
+
+func TestApkVersionService_GetApkFilePath(t *testing.T) {
+	db := setupAPKServiceTestDB(t)
+	defer db.Close()
+
+	// Create temporary directory for test
+	tmpDir, err := os.MkdirTemp("", "apk-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	repo := &repository.ApkVersionRepository{}
+	service := NewApkVersionService(repo)
+
+	// Set the repository's db
+	repoStruct := (*struct {
+		db *sql.DB
+	})(unsafe.Pointer(repo))
+	repoStruct.db = db
+
+	t.Run("get existing file path", func(t *testing.T) {
+		// Create a test file
+		testFilePath := filepath.Join(tmpDir, "test.apk")
+		err := os.WriteFile(testFilePath, []byte("test content"), 0644)
+		require.NoError(t, err)
+
+		// Insert test data
+		result, err := db.Exec(`INSERT INTO apk_versions (version, versionCode, fileName, fileSize, filePath, releaseNotes, isActive, uploadedAt)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "1.0.0", 1, "test.apk", 1000, testFilePath, "notes", 1, time.Now())
+		require.NoError(t, err)
+
+		id, err := result.LastInsertId()
+		require.NoError(t, err)
+
+		path, err := service.GetApkFilePath(int(id))
+		require.NoError(t, err)
+		assert.Equal(t, testFilePath, path)
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		path, err := service.GetApkFilePath(999)
+		assert.Error(t, err)
+		assert.Empty(t, path)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -11,21 +11,23 @@ import (
 
 // Services holds all service instances
 type Services struct {
-	Item    *ItemService
-	Store   *StoreService
-	Staff   *StaffService
-	Sale    *SaleService
-	Setting *SettingService
+	Item       *ItemService
+	Store      *StoreService
+	Staff      *StaffService
+	Sale       *SaleService
+	Setting    *SettingService
+	ApkVersion *ApkVersionService
 }
 
 // NewServices creates all service instances
 func NewServices(repos *repository.Repositories) *Services {
 	return &Services{
-		Item:    &ItemService{repo: repos.Item},
-		Store:   &StoreService{repo: repos.Store},
-		Staff:   &StaffService{repo: repos.Staff},
-		Sale:    &SaleService{repo: repos.Sale, itemRepo: repos.Item},
-		Setting: &SettingService{repo: repos.Setting},
+		Item:       &ItemService{repo: repos.Item},
+		Store:      &StoreService{repo: repos.Store},
+		Staff:      &StaffService{repo: repos.Staff},
+		Sale:       &SaleService{repo: repos.Sale, itemRepo: repos.Item},
+		Setting:    &SettingService{repo: repos.Setting},
+		ApkVersion: NewApkVersionService(repos.ApkVersion),
 	}
 }
 
@@ -113,6 +115,19 @@ func (s *StoreService) CreateStore(store *models.Store) error {
 	return s.repo.Create(store)
 }
 
+func (s *StoreService) UpdateStore(store *models.Store) error {
+	// Validate
+	if store.Name == "" {
+		return fmt.Errorf("store name is required")
+	}
+
+	return s.repo.Update(store)
+}
+
+func (s *StoreService) DeleteStore(id int) error {
+	return s.repo.Delete(id)
+}
+
 func (s *StoreService) generateStoreID() string {
 	return fmt.Sprintf("STORE-%s", uuid.New().String()[:8])
 }
@@ -142,6 +157,19 @@ func (s *StaffService) CreateStaff(staff *models.Staff) error {
 	}
 
 	return s.repo.Create(staff)
+}
+
+func (s *StaffService) UpdateStaff(staff *models.Staff) error {
+	// Validate
+	if staff.Name == "" {
+		return fmt.Errorf("staff name is required")
+	}
+
+	return s.repo.Update(staff)
+}
+
+func (s *StaffService) DeleteStaff(id int) error {
+	return s.repo.Delete(id)
 }
 
 func (s *StaffService) generateStaffID() string {

--- a/web/templates/apk/index.html
+++ b/web/templates/apk/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.title}} - KidsPOS</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" href="/">KidsPOS</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <a class="nav-link" href="/items">商品</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/sales">販売</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/stores">店舗</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/staffs">スタッフ</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/reports/sales">レポート</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/settings">設定</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" href="/apk">APK管理</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<div class="container mt-5">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h1>APKバージョン管理</h1>
+                <a href="/apk/upload" class="btn btn-primary">新規アップロード</a>
+            </div>
+
+            {{if .error}}
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                {{.error}}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+            {{end}}
+
+            {{if .versions}}
+            <div class="table-responsive">
+                <table class="table table-striped table-hover">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>バージョン</th>
+                            <th>バージョンコード</th>
+                            <th>ファイル名</th>
+                            <th>サイズ</th>
+                            <th>リリースノート</th>
+                            <th>状態</th>
+                            <th>アップロード日時</th>
+                            <th>操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{range .versions}}
+                        <tr>
+                            <td><strong>{{.Version}}</strong></td>
+                            <td>{{.VersionCode}}</td>
+                            <td>{{.FileName}}</td>
+                            <td>{{printf "%.2f" (div .FileSize 1048576.0)}} MB</td>
+                            <td>{{if .ReleaseNotes}}{{.ReleaseNotes}}{{else}}-{{end}}</td>
+                            <td>
+                                {{if .IsActive}}
+                                <span class="badge bg-success">有効</span>
+                                {{else}}
+                                <span class="badge bg-secondary">無効</span>
+                                {{end}}
+                            </td>
+                            <td>{{.UploadedAt.Format "2006-01-02 15:04"}}</td>
+                            <td>
+                                <a href="/api/apk/download/{{.ID}}" class="btn btn-sm btn-primary" download>ダウンロード</a>
+                            </td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+            </div>
+            {{else}}
+            <div class="alert alert-info" role="alert">
+                登録されているAPKバージョンはありません。
+            </div>
+            {{end}}
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/web/templates/apk/upload.html
+++ b/web/templates/apk/upload.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.title}} - KidsPOS</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" href="/">KidsPOS</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <a class="nav-link" href="/items">商品</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/sales">販売</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/stores">店舗</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/staffs">スタッフ</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/reports/sales">レポート</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/settings">設定</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" href="/apk">APK管理</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h2 class="mb-0">APKアップロード</h2>
+                </div>
+                <div class="card-body">
+                    {{if .error}}
+                    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                        {{.error}}
+                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                    </div>
+                    {{end}}
+
+                    <form method="POST" enctype="multipart/form-data">
+                        <div class="mb-3">
+                            <label for="file" class="form-label">APKファイル <span class="text-danger">*</span></label>
+                            <input type="file" class="form-control" id="file" name="file" accept=".apk" required>
+                            <div class="form-text">最大ファイルサイズ: 100MB</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="version" class="form-label">バージョン <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="version" name="version" placeholder="例: 1.0.0" required>
+                            <div class="form-text">セマンティックバージョニング形式を推奨 (例: 1.0.0)</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="versionCode" class="form-label">バージョンコード <span class="text-danger">*</span></label>
+                            <input type="number" class="form-control" id="versionCode" name="versionCode" min="1" placeholder="例: 1" required>
+                            <div class="form-text">整数値。新しいバージョンほど大きい値を指定してください</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="releaseNotes" class="form-label">リリースノート</label>
+                            <textarea class="form-control" id="releaseNotes" name="releaseNotes" rows="5" placeholder="このバージョンの変更内容や新機能を記載してください"></textarea>
+                        </div>
+
+                        <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+                            <a href="/apk" class="btn btn-secondary">キャンセル</a>
+                            <button type="submit" class="btn btn-primary">アップロード</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+// File size validation
+document.getElementById('file').addEventListener('change', function(e) {
+    const file = e.target.files[0];
+    if (file) {
+        const maxSize = 100 * 1024 * 1024; // 100MB
+        if (file.size > maxSize) {
+            alert('ファイルサイズが100MBを超えています。より小さいファイルを選択してください。');
+            e.target.value = '';
+        }
+    }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 概要

Staff/StoreエンティティのCRUD操作完全実装と、Androidアプリ用APKバージョン管理システムを追加しました。

## 実装内容

### 1. Staff/Store の削除・更新機能
- ✅ 物理削除の実装（論理削除ではなくデータベースから完全削除）
- ✅ 外部キー制約の自動チェック（販売履歴がある場合は削除を拒否）
- ✅ Web UIおよびREST API両方に対応
- ✅ エラーメッセージの改善

### 2. APKバージョン管理システム
- ✅ ファイルアップロード（multipart/form-data、最大100MB）
- ✅ セマンティックバージョニングとバージョンコードの管理
- ✅ OTA配信（Androidアプリから最新版の確認とダウンロード）
- ✅ リリースノート機能
- ✅ ローカルファイルシステムストレージ（./uploads/apk/）
- ✅ バージョン無効化（物理削除せず配信停止）
- ✅ Web UI（アップロード、一覧表示、ダウンロード）

### 3. 包括的なテストスイート
- ✅ リポジトリ層テスト（Staff/Store/APK CRUD操作）
- ✅ サービス層テスト（ビジネスロジックとファイル処理）
- ✅ 外部キー制約検証テスト
- ✅ 27テスト全て成功

## API エンドポイント

### 新規追加（8エンドポイント）
- `GET /api/apk/version/latest` - 最新APKバージョン取得
- `GET /api/apk/version/check?currentVersionCode=X` - アップデート確認
- `GET /api/apk/version/all` - 全APKバージョン取得
- `GET /api/apk/download/:id` - APKファイルダウンロード（ID指定）
- `GET /api/apk/download/latest` - 最新APKファイルダウンロード
- `POST /api/apk/upload` - APKファイルアップロード
- `DELETE /api/apk/version/:id` - APKバージョン削除（物理削除）
- `PUT /api/apk/version/:id/deactivate` - APKバージョン無効化

### 機能強化
- `DELETE /api/staffs/:id` - スタッフ削除（外部キー制約チェック付き）
- `PUT /api/staffs/:id` - スタッフ更新
- `DELETE /api/stores/:id` - 店舗削除（外部キー制約チェック付き）
- `PUT /api/stores/:id` - 店舗更新

## テスト結果

```bash
$ go test ./... -v
=== RUN   TestApkRepository_Create
--- PASS: TestApkRepository_Create (0.00s)
=== RUN   TestApkRepository_FindLatest
--- PASS: TestApkRepository_FindLatest (0.00s)
=== RUN   TestStaffRepository_Delete
--- PASS: TestStaffRepository_Delete (0.00s)
=== RUN   TestStoreRepository_Delete
--- PASS: TestStoreRepository_Delete (0.00s)
...（全27テスト成功）

PASS
ok      github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/repository    0.605s
ok      github.com/KidsPOSProject/KidsPOS-Server-GO/pkg/service       0.709s
```

## 技術的詳細

### データベース
- SQLiteに`apk_versions`テーブル追加
- 外部キー制約の有効化と参照整合性の保証
- インデックス最適化（versionCode, isActive, uploadedAt）

### ファイル管理
- UUID生成による一意なファイル名
- トランザクション処理（DB失敗時のファイルクリーンアップ）
- ファイル検証（拡張子、サイズ）

### セキュリティ
- ファイルサイズ制限（100MB）
- ファイル拡張子検証（.apkのみ）
- 外部キー制約による参照整合性保証

## 依存関係

新規追加:
- `github.com/stretchr/testify` - テスティングフレームワーク

## ブレイキングチェンジ

なし（全て後方互換性あり）

## チェックリスト

- [x] コードが正常にビルドできる
- [x] 全テストが成功する
- [x] README更新済み
- [x] .gitignore更新済み（build/, uploads/）
- [x] APIドキュメント更新済み
- [x] 外部キー制約の動作確認済み

## スクリーンショット

Web UIのスクリーンショットは後ほど追加予定

## レビュー観点

- [ ] 外部キー制約の処理が適切か
- [ ] ファイルアップロードのセキュリティ
- [ ] エラーハンドリング
- [ ] テストカバレッジ
- [ ] APIレスポンス形式の一貫性